### PR TITLE
Add missing precondition in blocksworld domain (3ops)

### DIFF
--- a/blocksworld/3ops/domain.pddl
+++ b/blocksworld/3ops/domain.pddl
@@ -5,7 +5,7 @@
 
 (:action move-b-to-b
   :parameters (?bm ?bf ?bt)
-  :precondition (and (clear ?bm) (clear ?bt) (on ?bm ?bf))
+  :precondition (and (clear ?bm) (clear ?bt) (on ?bm ?bf) (not (on ?bt ?bf)))
   :effect (and (not (clear ?bt)) (not (on ?bm ?bf))
                (on ?bm ?bt) (clear ?bf)))
 


### PR DESCRIPTION
Adds missing precondition to [move-b-to-b](https://github.com/AI-Planning/pddl-generators/blob/main/blocksworld/3ops/domain.pddl#L6). Details described in #38.

Resolves #38.