### PR TITLE
Upgrade CMake minimum required version

### DIFF
--- a/nomystery/CMakeLists.txt
+++ b/nomystery/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.4)
+cmake_minimum_required(VERSION 3.5)
 project(nomysterygenerator)
 
 set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Wall -pg")


### PR DESCRIPTION
In `nomystery` upgrade the CMake minimum required version from `3.4` to `3.5`, since compatibility with version `3.4` was deprecated in version `3.27` and [removed in `4.0`](https://cmake.org/cmake/help/latest/command/cmake_minimum_required.html) 