### PR TITLE
Add pathway missing headers

### DIFF
--- a/pathways/main.c
+++ b/pathways/main.c
@@ -8,6 +8,9 @@
 #include <string.h>
 #include <sys/time.h>
 
+#include <unistd.h>
+#include <libgen.h>
+
 int num_goals;
 float uno, cinque, dieci, coeff;
 


### PR DESCRIPTION
I am not able to compile `pathway` generator, adding the two headers `unistd.h` and `libgen.h` seems to solve the issue